### PR TITLE
Modify some scripts to run on Mac OSX

### DIFF
--- a/egs/swbd/local/swbd_data_prep.sh
+++ b/egs/swbd/local/swbd_data_prep.sh
@@ -19,13 +19,16 @@ fi
 # make everything lowercase here. This is because we will be using SRILM which
 # can optionally make everything lowercase (but not uppercase) when mapping
 # LM vocabs.
-awk '{
-       name=substr($1,1,6); gsub("^sw","sw0",name); side=substr($1,7,1);
-       stime=$2; etime=$3;
-       printf("%s-%s_%06.0f-%06.0f",
-              name, side, int(100*stime+0.5), int(100*etime+0.5));
-       for(i=4;i<=NF;i++) printf(" %s", $i); printf "\n"
-}' data/swbd1/swb_ms98_transcriptions/*/*/*-trans.text  > data/swbd1/transcripts1.txt
+> data/swbd1/transcripts1.txt
+for f in data/swbd1/swb_ms98_transcriptions/*/*/*-trans.text; do
+  awk '{
+         name=substr($1,1,6); gsub("^sw","sw0",name); side=substr($1,7,1);
+         stime=$2; etime=$3;
+         printf("%s-%s_%06.0f-%06.0f",
+                name, side, int(100*stime+0.5), int(100*etime+0.5));
+         for(i=4;i<=NF;i++) printf(" %s", $i); printf "\n"
+  }' $f >> data/swbd1/transcripts1.txt
+done
 
 # test if trans. file is sorted
 export LC_ALL=C;

--- a/scripts/prepare_int_data.sh
+++ b/scripts/prepare_int_data.sh
@@ -76,7 +76,7 @@ echo $num_words >$dir/num_words
 # we can include the preparation of the dev data in the following
 # by adding "0 dev" to the contents of $dir/names using cat.
 
-echo "dev dev" | cat - $dir/names | while read int name; do
+while read int name; do
   set -o pipefail
   ( if [ -f $text/$name.txt.gz ]; then gunzip -c $text/$name.txt.gz; else cat $text/$name.txt; fi | \
     text_to_int.py $vocab | gzip -c >$dir/$int.txt.gz ) 2>$dir/log/$int.log || touch $dir/.error &
@@ -87,7 +87,7 @@ echo "dev dev" | cat - $dir/names | while read int name; do
       exit 1
     fi
   fi
-done
+done < <(echo "dev dev" | cat - $dir/names)
 
 wait
 


### PR DESCRIPTION
1. Using a for-loop to avoid "Argument list too long" error for awk in egs/swbd/local/swbd_data_prep.sh.
2. Using process substitution instead of pipeline to wait the text_to_int-subprocess in scripts/prepare_int_data.sh.
   
   According to the [Bash manual](http://www.gnu.org/software/bash/manual/html_node/Pipelines.html), each command in a pipeline is executed in a subshell. Thus the while-process is a subprocess of main shell, and the working process, i.e. the text_to_init.py process, is the subprocess of subprocess of main shell. In the original script, the 'wait' command(on line 92) in main shell can't wait the working processes until they finish, but the while-process will finish immediately after forking all the working processes, finally the main script may exit before working processes finish.
   
   By replacing the pipeline with a process substitution, there is no intermediate process will be forked, so that the 'wait' command can work properly.
