### PR TITLE
add num_ngrams in pocolm LM dir

### DIFF
--- a/scripts/make_lm_dir.py
+++ b/scripts/make_lm_dir.py
@@ -144,6 +144,13 @@ print("make_lm_dir.py: running command {0}".format(command), file=sys.stderr)
 if os.system(command) != 0:
     sys.exit("make_lm_dir.py: error running command {0}".format(command))
 
+src = work_dir + os.sep + "num_ngrams"
+dst = args.lm_dir + os.sep + "num_ngrams"
+try:
+    shutil.copy(src, dst)
+except:
+    sys.exit("make_lm_dir.py: error copying {0} to {1}".format(src, dst))
+
 
 if args.keep_splits == 'true':
     f = open(args.lm_dir + '/num_splits', 'w')

--- a/scripts/validate_lm_dir.py
+++ b/scripts/validate_lm_dir.py
@@ -34,6 +34,20 @@ except Exception as e:
              "an integer >1: {1}".format(args.lm_dir, str(e)))
 f.close()
 
+# the following code checks num_ngrams
+try:
+    f = open("{0}/num_ngrams".format(args.lm_dir))
+    lines = f.readlines()
+    assert(len(lines) == ngram_order)
+    for order, line in enumerate(lines):
+        assert(len(line.split()) == 2)
+        assert(int(line.split()[0]) == order + 1)
+        assert(int(line.split()[1]) > 0)
+except Exception as e:
+    sys.exit("validate_lm_dir.py: Expected file {0}/num_ngrams to contain "
+             "an integer for every order each line: {1}".format(args.lm_dir, str(e)))
+f.close()
+
 # call validate_vocab.py to check the vocab.
 if os.system("validate_vocab.py {0}/words.txt".format(args.lm_dir)) != 0:
     sys.exit("validate_lm_dir.py: failed to validate {0}/words.txt".format(args.lm_dir))


### PR DESCRIPTION
Add a file named num_ngrams in all pocolm LM dir, who stores the num-ngrams of this model.

Some code changes in merge-float-counts and float-counts-prune to print the num-ngrams infomations.

Store this info when we build lm dir in make_lm_dir.py, and also after pruning in prune_lm_dir.py.

I was intend to check the nums in format_arpa.py, but the counts in arpa file is piped to stdout. so it is not easy to check that.
