### PR TITLE
add max-memory option for 'sort'

### DIFF
--- a/egs/swbd/run.sh
+++ b/egs/swbd/run.sh
@@ -12,11 +12,12 @@ arpa_dir="data/arpa/"
 
 max_memory='--max-memory=10G'
 # If you do not want to set memory limitation for "sort", you can use
-# max_memory = 
+#max_memory=
 # Choices for the max-memory can be:
-# 1) integer + 'G' or 'K' or 'M' ... 
-# 2) integer + 'b', meaning using default units and no multiplication
-# 3) integer + '%', meaning percentage of memory
+# 1) integer + 'K', 'M', 'G', ... 
+# 2) integer + 'b', meaning using default unit byte and no multiplication
+# 3) integer + '%', meaning a percentage of memory
+# 4) integer, default unit is byte
 
 fold_dev_opt=
 # If you want to fold the dev-set in to the 'swbd1' set to produce the final

--- a/egs/swbd_fisher/run.sh
+++ b/egs/swbd_fisher/run.sh
@@ -19,13 +19,14 @@ num_word=40000
 lm_dir="data/lm/"
 arpa_dir="data/arpa/"
 
-max_memory='--max-memory=20G'
-# If you do not want to set memory limitation for "sort", you can use 
-# max_memory = 
-# Choices for the max-memory can be: 
-# 1) integer + 'G' or 'K' or 'M' ... 
-# 2) integer + 'b', meaning using default units and no multiplication
-# 3) integer + '%', meaning percentage of memory
+max_memory='--max-memory=10G'
+# If you do not want to set memory limitation for "sort", you can use
+#max_memory=
+# Choices for the max-memory can be:
+# 1) integer + 'K', 'M', 'G', ... 
+# 2) integer + 'b', meaning using default unit byte and no multiplication
+# 3) integer + '%', meaning a percentage of memory
+# 4) integer, default unit is byte
 
 fold_dev_opt=
 # If you want to fold the dev-set in to the 'swbd1' set to produce the final

--- a/egs/swbd_fisher/run.sh
+++ b/egs/swbd_fisher/run.sh
@@ -41,7 +41,7 @@ bypass_metaparam_optim_opt=
 # You can find the values from output log of train_lm.py.
 # These example numbers of metaparameters is for 3-gram model running with train_lm.py.
 # the dev perplexity should be close to the non-bypassed model.
-#bypass_metaparam_optim_opt="--bypass-metaparameter-optimization=0.500,0.763,0.379,0.218,0.034,0.911,0.510,0.376,0.127"
+#bypass_metaparam_optim_opt="--bypass-metaparameter-optimization=0.091,0.867,0.753,0.275,0.100,0.018,0.902,0.371,0.183,0.070"
 # Note: to use these example parameters, you may need to remove the .done files
 # to make sure the make_lm_dir.py be called and tain only 3-gram model
 #for order in 3; do

--- a/egs/swbd_fisher/run.sh
+++ b/egs/swbd_fisher/run.sh
@@ -19,6 +19,14 @@ num_word=40000
 lm_dir="data/lm/"
 arpa_dir="data/arpa/"
 
+max_memory='--max-memory=20G'
+# If you do not want to set memory limitation for "sort", you can use 
+# max_memory = 
+# Choices for the max-memory can be: 
+# 1) integer + 'G' or 'K' or 'M' ... 
+# 2) integer + 'b', meaning using default units and no multiplication
+# 3) integer + '%', meaning percentage of memory
+
 fold_dev_opt=
 # If you want to fold the dev-set in to the 'swbd1' set to produce the final
 # model, un-comment the following line.  For use in the Kaldi example script for
@@ -45,36 +53,36 @@ for order in 3 4 5; do
   # Note: you'd use --wordlist if you had a previously determined word-list
   # that you wanted to use.
   # Note: the following might be a more reasonable setting:
-  # train_lm.py --num-word=${num_word} --num-splits=5 --warm-start-ratio=10 \
+  # train_lm.py --num-word=${num_word} --num-splits=5 --warm-start-ratio=10 ${max_memory} \
   #             --min-counts='fisher=2 swbd1=1' \
   #             --keep-int-data=true ${fold_dev_opt} ${bypass_metaparam_optim_opt} \
   #             data/text ${order} ${lm_dir}
-  train_lm.py --num-word=${num_word} --num-splits=5 --warm-start-ratio=10 \
+  train_lm.py --num-word=${num_word} --num-splits=5 --warm-start-ratio=10 ${max_memory} \
               --keep-int-data=true ${fold_dev_opt} ${bypass_metaparam_optim_opt} \
               data/text ${order} ${lm_dir}
   unpruned_lm_dir=${lm_dir}/${num_word}_${order}.pocolm
 
   mkdir -p ${arpa_dir}
-  format_arpa_lm.py ${unpruned_lm_dir} | gzip -c > ${arpa_dir}/${num_word}_${order}gram_unpruned.arpa.gz
+  format_arpa_lm.py ${max_memory} ${unpruned_lm_dir} | gzip -c > ${arpa_dir}/${num_word}_${order}gram_unpruned.arpa.gz
 
   # example of pruning.  note: the threshold can be less than or more than one.
-  get_data_prob.py data/text/dev.txt ${unpruned_lm_dir} 2>&1 | grep -F '[perplexity'
+  get_data_prob.py ${max_memory} data/text/dev.txt ${unpruned_lm_dir} 2>&1 | grep -F '[perplexity'
   for threshold in 1.0 2.0 4.0; do
     pruned_lm_dir=${lm_dir}/${num_word}_${order}_prune${threshold}.pocolm
-    prune_lm_dir.py --final-threshold=${threshold} ${unpruned_lm_dir} ${pruned_lm_dir} 2>&1 | tail -n 5 | head -n 3
-    get_data_prob.py data/text/dev.txt ${pruned_lm_dir} 2>&1 | grep -F '[perplexity'
+    prune_lm_dir.py --final-threshold=${threshold} ${max_memory} ${unpruned_lm_dir} ${pruned_lm_dir} 2>&1 | tail -n 5 | head -n 3
+    get_data_prob.py ${max_memory} data/text/dev.txt ${pruned_lm_dir} 2>&1 | grep -F '[perplexity'
 
-    format_arpa_lm.py ${pruned_lm_dir} | gzip -c > data/arpa/${num_word}_${order}gram_prune${threshold}.arpa.gz
+    format_arpa_lm.py ${max_memory} ${pruned_lm_dir} | gzip -c > data/arpa/${num_word}_${order}gram_prune${threshold}.arpa.gz
 
   done
 
   # example of pruning by size.
-  size=250000
+  size=1000000
   pruned_lm_dir=${lm_dir}/${num_word}_${order}_prune${size}.pocolm
-  prune_lm_dir.py --target-num-ngrams=${size} ${unpruned_lm_dir} ${pruned_lm_dir} 2>&1 | tail -n 8 | head -n 6 | grep -v 'log-prob changes'
-  get_data_prob.py data/text/dev.txt ${pruned_lm_dir} 2>&1 | grep -F '[perplexity'
+  prune_lm_dir.py --target-num-ngrams=${size} ${max_memory} ${unpruned_lm_dir} ${pruned_lm_dir} 2>&1 | tail -n 8 | head -n 6 | grep -v 'log-prob changes'
+  get_data_prob.py data/text/dev.txt ${max_memory} ${pruned_lm_dir} 2>&1 | grep -F '[perplexity'
 
-  format_arpa_lm.py ${pruned_lm_dir} | gzip -c > data/arpa/${num_word}_${order}gram_prune${size}.arpa.gz
+  format_arpa_lm.py ${max_memory} ${pruned_lm_dir} | gzip -c > data/arpa/${num_word}_${order}gram_prune${size}.arpa.gz
 
 done
 

--- a/scripts/format_arpa_lm.py
+++ b/scripts/format_arpa_lm.py
@@ -47,26 +47,20 @@ if args.max_memory != '':
     # valid string max_memory must have at least two items 
     if len(args.max_memory) >= 2:
         s = args.max_memory
-        # case1: valid string max_memory can be formatted as "integer + letter or '%'"
+        # valid string max_memory can be formatted as:
+        # "a positive integer + a letter or a '%'" or "a positive integer"
         # the unit of memory size can also be 'T', 'P', 'E', 'Z', or 'Y'. They
         # are not included here considering their rare use in practice
-        if s[-1] in ['b', '%', 'K', 'M', 'G']:
-            if not s[-2].isdigit():
-                sys.exit("format_arpa_lm.py: the penultimate item of --max-memory "
-                         "must be a digit.")
+        if s[-1] in ['b', '%', 'K', 'M', 'G'] or s[-1].isdigit():
+            for x in s[:-1]:
+                if not x.isdigit():
+                    sys.exit("format_arpa_lm.py: --max-memory should be formatted as "
+                             "'a positive integer' or 'a positive integer appended "
+                             "with 'b', 'K', 'M','G', or '%''.")
             # max memory size must be larger than zero
             if int(s[:-1]) == 0:
                 sys.exit("format_arpa_lm.py: --max-memory must be > 0 {unit}.".format(
                          unit = s[-1]))    
-        # case2: valid string max_memory can be a pure numerical value
-        elif s[-1].isdigit():
-            for x in s[:-1]:
-                if not x.isdigit():
-                    sys.exit("format_arpa_lm.py: if the last item of --max-memory is i"
-                             "a digit, all the rest items should also be digits.")
-            # max memory size must be larger than zero
-            if int(s) == 0:
-                sys.exit("format_arpa_lm.py: --max-memory must be > 0 bytes.")
         else:
             sys.exit("format_arpa_lm.py: the format of string --max-memory is not correct.")
     else:

--- a/scripts/get_data_prob.py
+++ b/scripts/get_data_prob.py
@@ -11,6 +11,8 @@ parser = argparse.ArgumentParser(description="This script evaluates the probabil
                                  "The perplexity is printed to the standard output.",
                                  formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 
+parser.add_argument("--max-memory", type=str, default='',
+                    help="Memory limitation for sort.")
 parser.add_argument("text_in", type=str,
                     help="Filename of input data (one sentence per line, no BOS or "
                     "EOS symbols; text or gzipped text")
@@ -59,6 +61,9 @@ os.environ['TMPDIR'] = work_dir
 
 ngram_order = GetNgramOrder(args.lm_dir_in)
 
+# set the memory restriction for "sort"
+sort_mem_opt = ("--buffer-size={0} ".format(args.max_memory))
+
 # create
 if args.text_in[-3:] == '.gz':
     command = "gunzip -c {0} | text_to_int.py {1}/words.txt ".format(args.lm_dir_in,
@@ -66,7 +71,8 @@ if args.text_in[-3:] == '.gz':
 else:
     command = "text_to_int.py {0}/words.txt <{1}".format(args.lm_dir_in,
                                                          args.text_in)
-command += "| get-text-counts {0} | sort | uniq -c | get-int-counts ".format(ngram_order)
+command += "| get-text-counts {0} | sort {1} | uniq -c | get-int-counts ".format(
+            ngram_order, sort_mem_opt)
 if num_splits == None:
     command += "{0}/int.dev".format(work_dir)
 else:

--- a/scripts/get_data_prob.py
+++ b/scripts/get_data_prob.py
@@ -38,26 +38,20 @@ if args.max_memory != '':
     # valid string max_memory must have at least two items 
     if len(args.max_memory) >= 2:
         s = args.max_memory
-        # case1: valid string max_memory can be formatted as "integer + letter or '%'"
+        # valid string max_memory can be formatted as:
+        # "a positive integer + a letter or a '%'" or "a positive integer"
         # the unit of memory size can also be 'T', 'P', 'E', 'Z', or 'Y'. They
         # are not included here considering their rare use in practice
-        if s[-1] in ['b', '%', 'K', 'M', 'G']:
-            if not s[-2].isdigit():
-                sys.exit("get_data_prob.py: the penultimate item of --max-memory "
-                         "must be a digit.")
+        if s[-1] in ['b', '%', 'K', 'M', 'G'] or s[-1].isdigit():
+            for x in s[:-1]:
+                if not x.isdigit():
+                    sys.exit("get_data_prob.py: --max-memory should be formatted as "
+                             "'a positive integer' or 'a positive integer appended "
+                             "with 'b', 'K', 'M','G', or '%''.")
             # max memory size must be larger than zero
             if int(s[:-1]) == 0:
                 sys.exit("get_data_prob.py: --max-memory must be > 0 {unit}.".format(
                          unit = s[-1]))    
-        # case2: valid string max_memory can be a pure numerical value
-        elif s[-1].isdigit():
-            for x in s[:-1]:
-                if not x.isdigit():
-                    sys.exit("get_data_prob.py: if the last item of --max-memory is i"
-                             "a digit, all the rest items should also be digits.")
-            # max memory size must be larger than zero
-            if int(s) == 0:
-                sys.exit("get_data_prob.py: --max-memory must be > 0 bytes.")
         else:
             sys.exit("get_data_prob.py: the format of string --max-memory is not correct.")
     else:

--- a/scripts/prune_lm_dir.py
+++ b/scripts/prune_lm_dir.py
@@ -56,6 +56,8 @@ parser.add_argument("--remove-zeros", type=str, choices=['true','false'],
                     'Only useful for debugging purposes.')
 parser.add_argument("--check-exact-divergence", type=str, choices=['true','false'],
                     default='true', help='')
+parser.add_argument("--max-memory", type=str, default='',
+                    help="Memory limitation for sort.")
 parser.add_argument("lm_dir_in",
                     help="Source directory, for the input language model.")
 parser.add_argument("lm_dir_out",
@@ -96,6 +98,9 @@ else:
     if len(steps) == 0:
         sys.exit("prune_lm_dir.py: 'steps' cannot be empty.")
 
+# set the memory restriction for "sort"
+sort_mem_opt = ("--buffer-size={0} ".format(args.max_memory))
+
 # returns num-words in this lm-dir.
 def GetNumWords(lm_dir_in):
     command = "tail -n 1 {0}/words.txt".format(lm_dir_in)
@@ -125,8 +130,8 @@ def GetTotalNumNgrams(lm_dir_in):
 # counts which may not be removed); it requires work/float.all
 # to exist.
 def CreateProtectedCounts(work):
-    command = ("bash -c 'float-counts-to-histories <{0}/float.all | LC_ALL=C sort |"
-               " histories-to-null-counts >{0}/protected.all'".format(work))
+    command = ("bash -c 'float-counts-to-histories <{0}/float.all | LC_ALL=C sort {1}|"
+               " histories-to-null-counts >{0}/protected.all'".format(work, sort_mem_opt))
     log_file = work + "/log/create_protected_counts.log"
     RunCommand(command, log_file, args.verbose == 'true')
 

--- a/scripts/prune_lm_dir.py
+++ b/scripts/prune_lm_dir.py
@@ -79,26 +79,20 @@ if args.max_memory != '':
     # valid string max_memory must have at least two items 
     if len(args.max_memory) >= 2:
         s = args.max_memory
-        # case1: valid string max_memory can be formatted as "integer + letter or '%'"
+        # valid string max_memory can be formatted as:
+        # "a positive integer + a letter or a '%'" or "a positive integer"
         # the unit of memory size can also be 'T', 'P', 'E', 'Z', or 'Y'. They
         # are not included here considering their rare use in practice
-        if s[-1] in ['b', '%', 'K', 'M', 'G']:
-            if not s[-2].isdigit():
-                sys.exit("prune_lm_dir.py: the penultimate item of --max-memory "
-                         "must be a digit.")
+        if s[-1] in ['b', '%', 'K', 'M', 'G'] or s[-1].isdigit():
+            for x in s[:-1]:
+                if not x.isdigit():
+                    sys.exit("prune_lm_dir.py: --max-memory should be formatted as "
+                             "'a positive integer' or 'a positive integer appended "
+                             "with 'b', 'K', 'M','G', or '%''.")
             # max memory size must be larger than zero
             if int(s[:-1]) == 0:
                 sys.exit("prune_lm_dir.py: --max-memory must be > 0 {unit}.".format(
                          unit = s[-1]))    
-        # case2: valid string max_memory can be a pure numerical value
-        elif s[-1].isdigit():
-            for x in s[:-1]:
-                if not x.isdigit():
-                    sys.exit("prune_lm_dir.py: if the last item of --max-memory is i"
-                             "a digit, all the rest items should also be digits.")
-            # max memory size must be larger than zero
-            if int(s) == 0:
-                sys.exit("prune_lm_dir.py: --max-memory must be > 0 bytes.")
         else:
             sys.exit("prune_lm_dir.py: the format of string --max-memory is not correct.")
     else:

--- a/scripts/train_lm.py
+++ b/scripts/train_lm.py
@@ -53,6 +53,8 @@ parser.add_argument("--keep-int-data",  type=str, choices=['true','false'],
                     default='false', help='whether to avoid the int-dir being cleanuped. '
                     'This is useful when user trains different orders of model with the same int-data. '
                     'It is valid only when --cleanup=true')
+parser.add_argument("--max-memory", type=str, default='',
+                    help="Memory limitation for sort.")
 parser.add_argument("text_dir",
                     help="Directory containing the training text.")
 parser.add_argument("order",
@@ -236,8 +238,8 @@ if os.path.exists(done_file):
     LogMessage("Skip getting counts")
 else:
     LogMessage("Getting ngram counts...")
-    command = "get_counts.py --min-counts='{0}' {1} {2} {3}".format(args.min_counts, \
-            int_dir, args.order, counts_dir)
+    command = "get_counts.py --min-counts='{0}' --max-memory={1} {2} {3} {4}".format(
+            args.min_counts, args.max_memory, int_dir, args.order, counts_dir)
     log_file = os.path.join(log_dir, 'get_counts.log')
     RunCommand(command, log_file, args.verbose == 'true')
     TouchFile(done_file)

--- a/scripts/train_lm.py
+++ b/scripts/train_lm.py
@@ -84,26 +84,20 @@ if args.max_memory != '':
     # valid string max_memory must have at least two items 
     if len(args.max_memory) >= 2:
         s = args.max_memory
-        # case1: valid string max_memory can be formatted as "integer + letter or '%'"
+        # valid string max_memory can be formatted as:
+        # "a positive integer + a letter or a '%'" or "a positive integer"
         # the unit of memory size can also be 'T', 'P', 'E', 'Z', or 'Y'. They
         # are not included here considering their rare use in practice
-        if s[-1] in ['b', '%', 'K', 'M', 'G']:
-            if not s[-2].isdigit():
-                sys.exit("train_lm.py: the penultimate item of --max-memory "
-                         "must be a digit.")
+        if s[-1] in ['b', '%', 'K', 'M', 'G'] or s[-1].isdigit():
+            for x in s[:-1]:
+                if not x.isdigit():
+                    sys.exit("train_lm.py: --max-memory should be formatted as "
+                             "'a positive integer' or 'a positive integer appended "
+                             "with 'b', 'K', 'M','G', or '%''.")
             # max memory size must be larger than zero
             if int(s[:-1]) == 0:
                 sys.exit("train_lm.py: --max-memory must be > 0 {unit}.".format(
                          unit = s[-1]))    
-        # case2: valid string max_memory can be a pure numerical value
-        elif s[-1].isdigit():
-            for x in s[:-1]:
-                if not x.isdigit():
-                    sys.exit("train_lm.py: if the last item of --max-memory is i"
-                             "a digit, all the rest items should also be digits.")
-            # max memory size must be larger than zero
-            if int(s) == 0:
-                sys.exit("train_lm.py: --max-memory must be > 0 bytes.")
         else:
             sys.exit("train_lm.py: the format of string --max-memory is not correct.")
     else:


### PR DESCRIPTION
add memory limitation option for 'sort' in top-level interface train_lm.py and other scripts call 'sort'
