### PR TITLE
add --limit-unk-history for get-text-counts

### DIFF
--- a/egs/swbd/run.sh
+++ b/egs/swbd/run.sh
@@ -43,7 +43,7 @@ bypass_metaparam_optim_opt=
 limit_unk_history_opt=
 # If you want to limit the left of <unk> in the history of a n-gram
 # un-comment the following line
-limit_unk_history_opt="--limit-unk-history=True"
+#limit_unk_history_opt="--limit-unk-history=true"
 
 for order in 3 4 5; do
   train_lm.py --num-words=${num_word} --num-splits=5 --warm-start-ratio=10 ${max_memory} \

--- a/egs/swbd/run.sh
+++ b/egs/swbd/run.sh
@@ -14,7 +14,7 @@ max_memory='--max-memory=10G'
 # If you do not want to set memory limitation for "sort", you can use
 #max_memory=
 # Choices for the max-memory can be:
-# 1) integer + 'K', 'M', 'G', ... 
+# 1) integer + 'K', 'M', 'G', ...
 # 2) integer + 'b', meaning unit is byte and no multiplication
 # 3) integer + '%', meaning a percentage of memory
 # 4) integer, default unit is 'K'
@@ -40,11 +40,15 @@ bypass_metaparam_optim_opt=
 #for order in 3; do
 #rm -f ${lm_dir}/${num_word}_${order}.pocolm/.done
 
+limit_unk_history_opt=
+# If you want to limit the left of <unk> in the history of a n-gram
+# un-comment the following line
+limit_unk_history_opt="--limit-unk-history=True"
 
 for order in 3 4 5; do
   train_lm.py --num-words=${num_word} --num-splits=5 --warm-start-ratio=10 ${max_memory} \
               --keep-int-data=true ${fold_dev_opt} ${bypass_metaparam_optim_opt} \
-              data/text ${order} ${lm_dir}
+              ${limit_unk_history_opt} data/text ${order} ${lm_dir}
   unpruned_lm_dir=${lm_dir}/${num_word}_${order}.pocolm
 
   mkdir -p ${arpa_dir}

--- a/egs/swbd_fisher/run.sh
+++ b/egs/swbd_fisher/run.sh
@@ -23,7 +23,7 @@ max_memory='--max-memory=10G'
 # If you do not want to set memory limitation for "sort", you can use
 #max_memory=
 # Choices for the max-memory can be:
-# 1) integer + 'K', 'M', 'G', ... 
+# 1) integer + 'K', 'M', 'G', ...
 # 2) integer + 'b', meaning unit is byte and no multiplication
 # 3) integer + '%', meaning a percentage of memory
 # 4) integer, default unit is 'K'
@@ -48,6 +48,10 @@ bypass_metaparam_optim_opt=
 #for order in 3; do
 #rm -f ${lm_dir}/${num_word}_${order}.pocolm/.done
 
+limit_unk_history_opt=
+# If you want to limit the left of <unk> in the history of a n-gram
+# un-comment the following line
+limit_unk_history_opt="--limit-unk-history=True"
 
 for order in 3 4 5; do
   # decide on the vocabulary.
@@ -57,10 +61,10 @@ for order in 3 4 5; do
   # train_lm.py --num-words=${num_word} --num-splits=5 --warm-start-ratio=10 ${max_memory} \
   #             --min-counts='fisher=2 swbd1=1' \
   #             --keep-int-data=true ${fold_dev_opt} ${bypass_metaparam_optim_opt} \
-  #             data/text ${order} ${lm_dir}
+  #             ${limit_unk_history_opt} data/text ${order} ${lm_dir}
   train_lm.py --num-words=${num_word} --num-splits=5 --warm-start-ratio=10 ${max_memory} \
               --keep-int-data=true ${fold_dev_opt} ${bypass_metaparam_optim_opt} \
-              data/text ${order} ${lm_dir}
+              ${limit_unk_history_opt} data/text ${order} ${lm_dir}
   unpruned_lm_dir=${lm_dir}/${num_word}_${order}.pocolm
 
   mkdir -p ${arpa_dir}

--- a/egs/swbd_fisher/run.sh
+++ b/egs/swbd_fisher/run.sh
@@ -51,7 +51,7 @@ bypass_metaparam_optim_opt=
 limit_unk_history_opt=
 # If you want to limit the left of <unk> in the history of a n-gram
 # un-comment the following line
-limit_unk_history_opt="--limit-unk-history=true"
+#limit_unk_history_opt="--limit-unk-history=true"
 
 for order in 3 4 5; do
   # decide on the vocabulary.

--- a/egs/swbd_fisher/run.sh
+++ b/egs/swbd_fisher/run.sh
@@ -51,7 +51,7 @@ bypass_metaparam_optim_opt=
 limit_unk_history_opt=
 # If you want to limit the left of <unk> in the history of a n-gram
 # un-comment the following line
-limit_unk_history_opt="--limit-unk-history=True"
+limit_unk_history_opt="--limit-unk-history=true"
 
 for order in 3 4 5; do
   # decide on the vocabulary.

--- a/scripts/get_counts.py
+++ b/scripts/get_counts.py
@@ -57,7 +57,8 @@ parser.add_argument("--num-count-jobs", type=int, default=4,
                     "getting initial counts")
 parser.add_argument("--max-memory", type=str, default='',
                     help="Memory limitation for sort.")
-parser.add_argument("--limit-unk-history", type=bool, default=False,
+parser.add_argument("--limit-unk-history", type=str, default='false',
+                    choices=['true','false'],
                     help="Truncate the left n-gram of an <unk> in history.")
 parser.add_argument("source_int_dir",
                     help="Specify <source_int_dir> the data-source")
@@ -276,7 +277,7 @@ def GetCountsSingleProcess(source_int_dir, dest_count_dir, ngram_order, n, num_s
             "get-text-counts {limit_unk_history} {ngram_order} | sort {mem_opt}| uniq -c | "\
             "get-int-counts {int_counts_output}'".format(source_int_dir = source_int_dir,
                                               n = n , ngram_order = ngram_order,
-                                              limit_unk_history = "--limit-unk-history" if args.limit_unk_history else "",
+                                              limit_unk_history = "--limit-unk-history" if args.limit_unk_history == 'true' else "",
                                               mem_opt = sort_mem_opt,
                                               int_counts_output = int_counts_output)
     log_file = "{dest_count_dir}/log/get_counts.{n}.log".format(
@@ -351,7 +352,7 @@ def GetCountsMultiProcess(source_int_dir, dest_count_dir, ngram_order, n, num_pr
                ' '.join(['{0}/{1}'.format(tempdir, p) for p in range(num_proc)]) + '& ' +
                'sort -m {0}'.format(sort_mem_opt) +
                ' '.join([ '<(get-text-counts {4} {0} <{1}/{2} | sort {3})'.format(ngram_order, tempdir, p, sort_mem_opt,
-                   "--limit-unk-history" if args.limit_unk_history else "")
+                   "--limit-unk-history" if args.limit_unk_history == 'true' else "")
                                        for p in range(num_proc) ]) +
                '| uniq -c | get-int-counts {0}'.format(int_counts_output) +
                "'") # end the quote from the 'bash -c'.

--- a/scripts/train_lm.py
+++ b/scripts/train_lm.py
@@ -43,6 +43,9 @@ parser.add_argument("--bypass-metaparameter-optimization", type=str, default=Non
                     "a comma separated list. If this is specified, the stages of metaparameter optimization "
                     "would be completely bypassed. One can get the approaviate numbers after "
                     "running one time of train_lm.py.")
+parser.add_argument("--limit-unk-history", type=bool,
+                    help="If True, the left words of <unk> in history of a n-gram will be truncated. "
+                    "run 'get_counts.py -h' to see the details on how to set this option.")
 parser.add_argument("--verbose", type=str, default='false',
                     choices=['true','false'],
                     help="If true, print commands as we execute them.")
@@ -284,8 +287,9 @@ if not CheckFreshness(done_file, last_done_files):
     LogMessage("Skip getting counts")
 else:
     LogMessage("Getting ngram counts...")
-    command = "get_counts.py --min-counts='{0}' --max-memory={1} {2} {3} {4}".format(
-            args.min_counts, args.max_memory, int_dir, args.order, counts_dir)
+    command = "get_counts.py --min-counts='{0}' --max-memory={1} {5} {2} {3} {4}".format(
+            args.min_counts, args.max_memory, int_dir, args.order, counts_dir,
+            "--limit-unk-history=True" if args.limit_unk_history else "")
     log_file = os.path.join(log_dir, 'get_counts.log')
     RunCommand(command, log_file, args.verbose == 'true')
     TouchFile(done_file)

--- a/scripts/train_lm.py
+++ b/scripts/train_lm.py
@@ -33,6 +33,10 @@ parser.add_argument("--warm-start-ratio", type=int, default=10,
 parser.add_argument("--min-counts", type=str, default='',
                     help="If specified, apply min-count when we get the ngram counts from training text. "
                          "run 'get_counts.py -h' to see the details on how to set this option.")
+parser.add_argument("--limit-unk-history", type=str, default='false',
+                    choices=['true','false'],
+                    help="If true, the left words of <unk> in history of a n-gram will be truncated. "
+                    "run 'get_counts.py -h' to see the details on how to set this option.")
 parser.add_argument("--fold-dev-into", type=str,
                     help="If supplied, the name of data-source into which to fold the "
                     "counts of the dev data when building the model (typically the "
@@ -43,9 +47,6 @@ parser.add_argument("--bypass-metaparameter-optimization", type=str, default=Non
                     "a comma separated list. If this is specified, the stages of metaparameter optimization "
                     "would be completely bypassed. One can get the approaviate numbers after "
                     "running one time of train_lm.py.")
-parser.add_argument("--limit-unk-history", type=bool,
-                    help="If True, the left words of <unk> in history of a n-gram will be truncated. "
-                    "run 'get_counts.py -h' to see the details on how to set this option.")
 parser.add_argument("--verbose", type=str, default='false',
                     choices=['true','false'],
                     help="If true, print commands as we execute them.")
@@ -287,9 +288,9 @@ if not CheckFreshness(done_file, last_done_files):
     LogMessage("Skip getting counts")
 else:
     LogMessage("Getting ngram counts...")
-    command = "get_counts.py --min-counts='{0}' --max-memory={1} {5} {2} {3} {4}".format(
+    command = "get_counts.py --min-counts='{0}' --max-memory={1} --limit-unk-history={5} {2} {3} {4}".format(
             args.min_counts, args.max_memory, int_dir, args.order, counts_dir,
-            "--limit-unk-history=True" if args.limit_unk_history else "")
+            args.limit_unk_history)
     log_file = os.path.join(log_dir, 'get_counts.log')
     RunCommand(command, log_file, args.verbose == 'true')
     TouchFile(done_file)


### PR DESCRIPTION
Addressing issue #62. Added an option to get-text-counts and the related scripts, example of usage is in egs/swbd/run.sh.

Test outputs of get-text-counts are:

```
$ (echo 11 12 13 14; echo 11 3 3 13; echo 11 12 3 13) | ./get-text-counts --limit-unk-history 4
      1      11
     11       1      12
     12      11       1      13
     13      12      11      14
     14      13      12       2
      1      11
     11       1       3
      3       3
      3      13
     13       3       2
      1      11
     11       1      12
     12      11       1       3
      3      13
     13       3       2
get-text-counts: processed 3 lines, with (on average) 6 words per line.
```
