### PR TITLE
Fix for sort memory buffer calculation in python3

### DIFF
--- a/scripts/get_counts.py
+++ b/scripts/get_counts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # we're using python 3.x style print but want it to work in python 2.x,
-from __future__ import print_function
+from __future__ import print_function, division
 import os
 import argparse
 import sys
@@ -457,7 +457,7 @@ def ParseMemoryString(s):
 
 def DivideMemory(total, n):
     (value, unit) = ParseMemoryString(total)
-    sub_memory = value / n
+    sub_memory = value // n
     if sub_memory != float(value) / n:
         if unit in ['K', 'k', '']:
             sub_memory = value * 1024 / n


### PR DESCRIPTION
This is a fix for an issue with memory buffer size calculation for the `sort` command - in Python 3, `/` operator does not truncate the result of int by int division and the code never entered the branch with correct calculation.