### PR TITLE
UTF-8 support in validate_vocab.py

### DIFF
--- a/egs/swbd/local/map_acronyms_transcripts.py
+++ b/egs/swbd/local/map_acronyms_transcripts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # convert acronyms in swbd transcript to fisher convention
 # accoring to first two columns in the input acronyms mapping
 

--- a/scripts/check_dependencies.sh
+++ b/scripts/check_dependencies.sh
@@ -43,27 +43,22 @@ fi
 
 if which python >&/dev/null ; then
   version=`/usr/bin/env python 2>&1 --version | awk '{print $2}' `
-  if [[ $version != "2.7"* && $version != "3."* ]] ; then
+  if [[ $version != "3."* ]] ; then
     status=1
-    if which python2.7 >&/dev/null ; then
-      echo "$0: python 2.7 is not the default python (lower version python does not "
-      echo "$0: have packages that are required by pocolm). You should make it default"
-    else
-      echo "$0: python 2.7 is not installed"
-      add_packages python2.7 python2.7 python2.7
-    fi
+    echo "$0: python 3 is not installed"
+    add_packages python3 python3 python3
   fi
 
 else
-  echo "$0: python 2.7 is not installed"
-  add_packages python2.7 python2.7 python2.7
+  echo "$0: python 3 is not installed"
+  add_packages python3 python3 python3
 fi
 
 if ! python -c 'import numpy' >&/dev/null; then
   echo "$0: python-numpy is not installed"
   # I'm not sure if this package name is OK for all distributions, this is what
   # it seems to be called on Debian.  We'll have to investigate this.
-  add_packages numpy python-numpy python-numpy
+  add_packages numpy python3-numpy python3-numpy
 fi
 
 printed=false

--- a/scripts/cleanup_count_dir.py
+++ b/scripts/cleanup_count_dir.py
@@ -34,12 +34,12 @@ def CleanupDir(count_dir, ngram_order, num_train_sets):
 if os.system("validate_count_dir.py " + args.count_dir) != 0:
     sys.exit("command validate_count_dir.py {0} failed".format(args.count_dir))
 
-f = open(os.path.join(args.count_dir, 'ngram_order'))
+f = open(os.path.join(args.count_dir, 'ngram_order'), encoding="utf-8")
 line = f.readline()
 ngram_order = int(line)
 f.close()
 
-f = open(os.path.join(args.count_dir, 'num_train_sets'))
+f = open(os.path.join(args.count_dir, 'num_train_sets'), encoding="utf-8")
 line = f.readline()
 num_train_sets = int(line)
 f.close()

--- a/scripts/cleanup_count_dir.py
+++ b/scripts/cleanup_count_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/cleanup_int_dir.py
+++ b/scripts/cleanup_int_dir.py
@@ -22,7 +22,7 @@ os.environ['PATH'] = (os.environ['PATH'] + os.pathsep +
 if os.system("validate_int_dir.py " + args.int_dir) != 0:
     sys.exit("command validate_int_dir.py {0} failed".format(args.int_dir))
 
-f = open(os.path.join(args.int_dir, 'num_train_sets'))
+f = open(os.path.join(args.int_dir, 'num_train_sets'), encoding="utf-8")
 line = f.readline()
 num_train_sets = int(line)
 f.close()

--- a/scripts/cleanup_int_dir.py
+++ b/scripts/cleanup_int_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/format_arpa_lm.py
+++ b/scripts/format_arpa_lm.py
@@ -114,7 +114,7 @@ def DivideMemory(total, n):
 
 
 # read ngram order.
-f = open(args.lm_dir + "/ngram_order")
+f = open(args.lm_dir + "/ngram_order", encoding="utf-8")
 ngram_order = int(f.readline())
 f.close()
 
@@ -141,7 +141,7 @@ if not os.path.exists(args.lm_dir + "/num_splits"):
                    lm_dir=args.lm_dir, mem_opt=mem_opt))
 else:
     # reading num_splits shouldn't fail, we validated the directory.
-    num_splits = int(open(args.lm_dir + "/num_splits").readline())
+    num_splits = int(open(args.lm_dir + "/num_splits").readline(), encoding="utf-8")
     if args.max_memory == '':
         mem_opt = ''
     else:

--- a/scripts/format_arpa_lm.py
+++ b/scripts/format_arpa_lm.py
@@ -141,7 +141,7 @@ if not os.path.exists(args.lm_dir + "/num_splits"):
                    lm_dir=args.lm_dir, mem_opt=mem_opt))
 else:
     # reading num_splits shouldn't fail, we validated the directory.
-    num_splits = int(open(args.lm_dir + "/num_splits").readline(), encoding="utf-8")
+    num_splits = int(open(args.lm_dir + "/num_splits", encoding="utf-8").readline())
     if args.max_memory == '':
         mem_opt = ''
     else:

--- a/scripts/format_arpa_lm.py
+++ b/scripts/format_arpa_lm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/get_counts.py
+++ b/scripts/get_counts.py
@@ -83,7 +83,7 @@ os.environ['TMPDIR'] = args.dest_count_dir
 # and so on), and returns a dictionary from integer id to name.
 def ReadNames(names_file):
     try:
-        f = open(names_file, "r")
+        f = open(names_file, "r", encoding="utf-8")
     except:
         sys.exit("get_counts.py: failed to open --names={0}"
                  " for reading".format(names_file))
@@ -104,7 +104,7 @@ def ReadNames(names_file):
 
 
 def GetNumTrainSets(source_int_dir):
-    f = open(source_int_dir + '/num_train_sets')
+    f = open(source_int_dir + '/num_train_sets', encoding="utf-8")
     # the following should not fail, since we validated source_int_dir.
     num_train_sets = int(f.readline())
     assert f.readline() == ''
@@ -258,7 +258,7 @@ def FormatMinCounts(source_int_dir, num_train_sets, ngram_order, min_counts):
 # save the n-gram order.
 def SaveNgramOrder(dest_count_dir, ngram_order):
     try:
-        f = open('{0}/ngram_order'.format(dest_count_dir), 'w')
+        f = open('{0}/ngram_order'.format(dest_count_dir), 'w', encoding="utf-8")
     except:
         ExitProgram('error opening file {0}/ngram_order for writing'.format(dest_count_dir))
     assert ngram_order >= 2
@@ -493,7 +493,7 @@ if args.ngram_order < 2:
 # read the variable 'num_train_sets'
 # from the corresponding file in source_int_dir  This shouldn't fail
 # because we just called validate_int-dir.py..
-f = open(args.source_int_dir + "/num_train_sets")
+f = open(args.source_int_dir + "/num_train_sets", encoding="utf-8")
 num_train_sets = int(f.readline())
 f.close()
 

--- a/scripts/get_counts.py
+++ b/scripts/get_counts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function, division

--- a/scripts/get_data_prob.py
+++ b/scripts/get_data_prob.py
@@ -68,7 +68,7 @@ if args.max_memory != '':
 num_splits = None
 
 if os.path.exists(args.lm_dir_in + "/num_splits"):
-    f = open(args.lm_dir_in + "/num_splits")
+    f = open(args.lm_dir_in + "/num_splits", encoding="utf-8")
     num_splits = int(f.readline())
     f.close()
 
@@ -77,7 +77,7 @@ if not os.path.exists(args.text_in):
 
 
 def GetNgramOrder(lm_dir):
-    f = open(lm_dir + "/ngram_order")
+    f = open(lm_dir + "/ngram_order", encoding="utf-8")
     return int(f.readline())
 
 

--- a/scripts/get_data_prob.py
+++ b/scripts/get_data_prob.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/get_objf_and_derivs.py
+++ b/scripts/get_objf_and_derivs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/get_objf_and_derivs.py
+++ b/scripts/get_objf_and_derivs.py
@@ -61,7 +61,7 @@ if os.system("validate_count_dir.py " + args.count_dir) != 0:
 # read the variables 'ngram_order', 'num_train_sets' and 'num_words'
 # from the corresponding files in count_dir.
 for name in ['ngram_order', 'num_train_sets', 'num_words']:
-    f = open(args.count_dir + os.sep + name)
+    f = open(args.count_dir + os.sep + name, encoding="utf-8")
     globals()[name] = int(f.readline())
     f.close()
 
@@ -84,7 +84,7 @@ if os.system("validate_metaparameters.py --ngram-order={ngram_order} "
 # train_set_scale will be a map from integer
 # training-set number to floating-point scale.  Note: there is no checking
 # because we already called validate_metaparameters.py.
-f = open(args.metaparameters, "r")
+f = open(args.metaparameters, "r", encoding="utf-8")
 train_set_scale = {}
 for n in range(1, num_train_sets + 1):
     train_set_scale[n] = float(f.readline().split()[1])
@@ -235,7 +235,7 @@ def DiscountCountsOrder1Backward():
 def ParseNumNgrams(out_dir, merge_all_orders_log):
     try:
         num = []
-        f = open(merge_all_orders_log, "r")
+        f = open(merge_all_orders_log, "r", encoding="utf-8")
         for line in f:
             if line[0] == '#':
                 continue
@@ -254,7 +254,7 @@ def ParseNumNgrams(out_dir, merge_all_orders_log):
 
     try:
         out_file = out_dir + "/num_ngrams"
-        f = open(out_file, "w")
+        f = open(out_file, "w", encoding="utf-8")
         for order, num in enumerate(nums):
             print(str(order + 1) + ' ' + str(num), file=f)
         f.close()
@@ -291,7 +291,7 @@ def ComputeObjfAndFinalDerivs(need_derivs):
           "words".format(objf, num_dev_set_words), file=sys.stderr)
     # Write the objective function.
     try:
-        f = open(args.objf_out, "w")
+        f = open(args.objf_out, "w", encoding="utf-8")
         print(str(objf), file=f)
         f.close()
     except:
@@ -301,7 +301,7 @@ def ComputeObjfAndFinalDerivs(need_derivs):
 
 def WriteDerivs():
     try:
-        f = open(args.derivs_out, "w")
+        f = open(args.derivs_out, "w", encoding="utf-8")
     except:
         sys.exit("get_objf_and_derivs.py: error opening --derivs-out={0} for writing".format(
                  args.derivs_out))

--- a/scripts/get_objf_and_derivs_split.py
+++ b/scripts/get_objf_and_derivs_split.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/get_objf_and_derivs_split.py
+++ b/scripts/get_objf_and_derivs_split.py
@@ -91,7 +91,7 @@ if not os.path.exists(args.work_dir + "/log"):
 # from the corresponding files in count_dir.  (this should be the
 # same as in the split directories; if not, you have a big problem).
 for name in ['ngram_order', 'num_train_sets', 'num_words']:
-    f = open(args.count_dir + os.sep + name)
+    f = open(args.count_dir + os.sep + name, encoding="utf-8")
     globals()[name] = int(f.readline())
     f.close()
 
@@ -114,7 +114,7 @@ if os.system("validate_metaparameters.py --ngram-order={ngram_order} "
 # train_set_scale will be a map from integer
 # training-set number to floating-point scale.  Note: there is no checking
 # because we already called validate_metaparameters.py.
-f = open(args.metaparameters, "r")
+f = open(args.metaparameters, "r", encoding="utf-8")
 train_set_scale = {}
 for n in range(1, num_train_sets + 1):
     train_set_scale[n] = float(f.readline().split()[1])
@@ -321,7 +321,7 @@ def DiscountCountsOrder1Backward():
 def WriteNumNgrams(out_dir, num_ngrams):
     out_file = out_dir + "/num_ngrams"
     try:
-        f = open(out_file, "w")
+        f = open(out_file, "w", encoding="utf-8")
         for order, num in enumerate(num_ngrams):
             print(str(order + 1) + ' ' + str(num), file=f)
         f.close()
@@ -332,7 +332,7 @@ def WriteNumNgrams(out_dir, num_ngrams):
 def ParseNumNgrams(out_dir, merge_all_orders_log):
     try:
         num_ngrams = []
-        f = open(merge_all_orders_log, "r")
+        f = open(merge_all_orders_log, "r", encoding="utf-8")
         for line in f:
             if line[0] == '#':
                 continue
@@ -358,7 +358,7 @@ def CombineNumNgrams():
         this_split_work = "{0}/{1}".format(split_work_dir, split_index)
         num_file = this_split_work + "/num_ngrams"
         try:
-            f = open(num_file, "r")
+            f = open(num_file, "r", encoding="utf-8")
             for order, line in enumerate(f):
                 num = int(line.split()[1])
                 assert(num > 0)
@@ -433,7 +433,7 @@ def WriteObjectiveFunction():
           "words".format(objf, num_dev_set_words_total), file=sys.stderr)
     # Write the objective function.
     try:
-        f = open(args.objf_out, "w")
+        f = open(args.objf_out, "w", encoding="utf-8")
         print(str(objf), file=f)
         f.close()
     except:
@@ -443,7 +443,7 @@ def WriteObjectiveFunction():
 
 def WriteDerivs():
     try:
-        f = open(args.derivs_out, "w")
+        f = open(args.derivs_out, "w", encoding="utf-8")
     except:
         ExitProgram("get_objf_and_derivs_split.py: error opening --derivs-out={0} for writing".format(
                  args.derivs_out))

--- a/scripts/get_unigram_weights.py
+++ b/scripts/get_unigram_weights.py
@@ -33,7 +33,7 @@ args = parser.parse_args()
 # count.
 def ReadCountsFile(counts_file):
     try:
-        f = open(counts_file, "r")
+        f = open(counts_file, "r", encoding="utf-8")
     except:
         sys.exit("Failed to open {0} for reading".format(counts_file))
     word_to_count = defaultdict(int)

--- a/scripts/get_unigram_weights.py
+++ b/scripts/get_unigram_weights.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/get_word_counts.py
+++ b/scripts/get_word_counts.py
@@ -40,9 +40,9 @@ if not os.path.exists(args.count_dir):
 def ProcessFile(text_file, counts_file):
     try:
         if text_file.endswith(".gz"):
-            f = gzip.open(text_file, 'r')
+            f = gzip.open(text_file, 'rt', encoding="utf-8")
         else:
-            f = open(text_file, 'r')
+            f = open(text_file, 'r', encoding="utf-8")
     except Exception as e:
         sys.exit("Failed to open {0} for reading: {1}".format(
                 text_file, str(e)))
@@ -52,7 +52,7 @@ def ProcessFile(text_file, counts_file):
             word_to_count[word] += 1
     f.close()
     try:
-        cf = open(counts_file, "w")
+        cf = open(counts_file, "w", encoding="utf-8")
     except:
         sys.exit("Failed to open {0} for writing".format(text_file))
     for word, count in word_to_count.items():

--- a/scripts/get_word_counts.py
+++ b/scripts/get_word_counts.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/initialize_metaparameters.py
+++ b/scripts/initialize_metaparameters.py
@@ -34,7 +34,7 @@ args = parser.parse_args()
 # and so on), and returns a dictionary from integer id to name.
 def ReadNames(names_file):
     try:
-        f = open(names_file, "r")
+        f = open(names_file, "r", encoding="utf-8")
     except:
         sys.exit("initialize_metaparameters.py: failed to open --names={0}"
                  " for reading".format(names_file))
@@ -59,7 +59,7 @@ def ReadNames(names_file):
 # floating-point weight.
 def ReadWeights(weights_file):
     try:
-        f = open(weights_file, "r")
+        f = open(weights_file, "r", encoding="utf-8")
     except:
         sys.exit("initialize_metaparameters.py: failed to open --weights={0}"
                  " for reading".format(weights_file))

--- a/scripts/initialize_metaparameters.py
+++ b/scripts/initialize_metaparameters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/internal/bfgs.py
+++ b/scripts/internal/bfgs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import math

--- a/scripts/internal/get_names.py
+++ b/scripts/internal/get_names.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/internal/pocolm_common.py
+++ b/scripts/internal/pocolm_common.py
@@ -23,7 +23,7 @@ def RunCommand(command, log_file, verbose=False):
                 os.path.basename(sys.argv[0]), command, log_file),
               file=sys.stderr)
     try:
-        f = open(log_file, 'w')
+        f = open(log_file, 'w', encoding="utf-8")
     except:
         ExitProgram('error opening log file {0} for writing'.format(log_file))
 
@@ -50,7 +50,7 @@ def GetCommandStdout(command, log_file, verbose=False):
               file=sys.stderr)
 
     try:
-        f = open(log_file, 'w')
+        f = open(log_file, 'w', encoding="utf-8")
     except:
         ExitProgram('error opening log file {0} for writing'.format(log_file))
 
@@ -82,7 +82,7 @@ def TouchFile(fname):
     if os.path.exists(fname):
         os.utime(fname, None)
     else:
-        open(fname, 'a').close()
+        open(fname, 'a').close(, encoding="utf-8")
 
 
 def LogMessage(message):

--- a/scripts/internal/pocolm_common.py
+++ b/scripts/internal/pocolm_common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/internal/pocolm_common.py
+++ b/scripts/internal/pocolm_common.py
@@ -82,7 +82,7 @@ def TouchFile(fname):
     if os.path.exists(fname):
         os.utime(fname, None)
     else:
-        open(fname, 'a').close(, encoding="utf-8")
+        open(fname, 'a', encoding="utf-8").close()
 
 
 def LogMessage(message):

--- a/scripts/internal/prune_size_model.py
+++ b/scripts/internal/prune_size_model.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 from __future__ import print_function
 import math

--- a/scripts/make_lm_dir.py
+++ b/scripts/make_lm_dir.py
@@ -64,7 +64,7 @@ if os.system("validate_count_dir.py " + args.count_dir) != 0:
 # read the variables 'ngram_order', 'num_train_sets' and 'num_words'
 # from the corresponding files in count_dir.
 for name in ['ngram_order', 'num_train_sets', 'num_words']:
-    f = open(args.count_dir + os.sep + name)
+    f = open(args.count_dir + os.sep + name, encoding="utf-8")
     globals()[name] = int(f.readline())
     f.close()
 
@@ -91,7 +91,7 @@ fold_dev_opt = ''
 
 if args.fold_dev_into is not None:
     fold_dev_into_int = None
-    f = open(args.count_dir + "/names")
+    f = open(args.count_dir + "/names", encoding="utf-8")
     for line in f.readlines():
         # we already validated the count-dir so we can assume the names file is
         # correctly formatted.
@@ -127,7 +127,7 @@ except:
             args.metaparameters,
             args.lm_dir + os.sep + "metaparameters"))
 
-f = open(args.lm_dir + "/was_pruned", "w")
+f = open(args.lm_dir + "/was_pruned", "w", encoding="utf-8")
 print("false", file=f)
 f.close()
 
@@ -167,7 +167,7 @@ except:
 
 
 if args.keep_splits == 'true':
-    f = open(args.lm_dir + '/num_splits', 'w')
+    f = open(args.lm_dir + '/num_splits', 'w', encoding="utf-8")
     print(str(args.num_splits), file=f)
     f.close()
     for i in range(1, args.num_splits + 1):

--- a/scripts/make_lm_dir.py
+++ b/scripts/make_lm_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/optimize_metaparameters.py
+++ b/scripts/optimize_metaparameters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/optimize_metaparameters.py
+++ b/scripts/optimize_metaparameters.py
@@ -85,7 +85,7 @@ if not os.path.exists(args.optimize_dir + "/work"):
 # read the variables 'ngram_order' and 'num_train_sets'
 # from the corresponding files in count_dir.
 for name in ['ngram_order', 'num_train_sets']:
-    f = open(args.count_dir + os.sep + name)
+    f = open(args.count_dir + os.sep + name, encoding="utf-8")
     globals()[name] = int(f.readline())
     f.close()
 
@@ -117,7 +117,7 @@ else:
 
 
 def ReadObjf(file):
-    f = open(file, "r")
+    f = open(file, "r", encoding="utf-8")
     line = f.readline()
     assert len(line.split()) == 1
     assert f.readline() == ''
@@ -132,7 +132,7 @@ metaparameter_names = None
 
 def ReadMetaparametersOrDerivs(file):
     global metaparameter_names
-    f = open(file, "r")
+    f = open(file, "r", encoding="utf-8")
     a = f.readlines()
     if metaparameter_names is None:
         metaparameter_names = [line.split()[0] for line in a]
@@ -148,7 +148,7 @@ def ReadMetaparametersOrDerivs(file):
 # to file 'file'; it returns true if the file was newly created and/or
 # had different contents than its previous contents.
 def WriteMetaparameters(file, array):
-    f = open(file + ".tmp", "w")
+    f = open(file + ".tmp", "w", encoding="utf-8")
     assert len(array) == len(metaparameter_names)
 
     # Even though mathematically none of the values can be <= 0 or >= 1, they

--- a/scripts/prepare_int_data.py
+++ b/scripts/prepare_int_data.py
@@ -42,7 +42,7 @@ args = parser.parse_args()
 
 
 def GetNumTrainSets(int_dir):
-    with open(int_dir) as f:
+    with open(int_dir, encoding="utf-8") as f:
         for line in f:
             try:
                 a = line.split()
@@ -133,18 +133,18 @@ GetNames(args.text_dir, args.int_dir)
 CopyFile(args.vocab, args.int_dir + "/words.txt")
 
 # get file 'num_train_sets' in int_dir from file 'names' in int_dir
-with open(args.int_dir + os.sep + "num_train_sets", "w") as f:
+with open(args.int_dir + os.sep + "num_train_sets", "w", encoding="utf-8") as f:
     num_train_sets = GetNumTrainSets(args.int_dir + os.sep + "names")
     f.write(str(num_train_sets) + "\n")
 
 # get file 'num_words' in int_dir from vocab
-with open(args.int_dir + os.sep + "num_words", "w") as f:
+with open(args.int_dir + os.sep + "num_words", "w", encoding="utf-8") as f:
     num_words = GetNumWords(args.vocab)
     f.write(str(num_words) + "\n")
 
 # parallel/sequential processing
 threads = []
-with open(args.int_dir + "/names", "r") as f:
+with open(args.int_dir + "/names", "r", encoding="utf-8") as f:
     for line in f:
         [int, name] = line.split()
         threads.append(threading.Thread(target=GetData, args=[int, name]))

--- a/scripts/prepare_int_data.py
+++ b/scripts/prepare_int_data.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/prune_lm_dir.py
+++ b/scripts/prune_lm_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/prune_lm_dir.py
+++ b/scripts/prune_lm_dir.py
@@ -258,7 +258,7 @@ def GetInitialLogprob():
                    float_star=float_star))
     try:
         print(command, file=sys.stderr)
-        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True, encoding="utf-8")
+        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
         # the stdout of this program will be something like:
         # 1.63388e+06 -7.39182e+06 10.5411 41.237 49.6758
         # representing: total-count, total-like, and for each order, the like-change
@@ -306,7 +306,7 @@ def RunPruneStep(work_in, work_out, threshold):
         print("# " + command, file=f)
     try:
         print(command, file=sys.stderr)
-        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True, encoding="utf-8")
+        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
         [word_count, like_change] = p.stdout.readline().split()
         like_change_per_word = float(like_change) / float(word_count)
         [tot_xgrams, shadowed, protected, pruned] = p.stdout.readline().split()

--- a/scripts/prune_lm_dir.py
+++ b/scripts/prune_lm_dir.py
@@ -116,7 +116,7 @@ if args.max_memory != '':
 
 num_splits = None
 if os.path.exists(args.lm_dir_in + "/num_splits"):
-    f = open(args.lm_dir_in + "/num_splits")
+    f = open(args.lm_dir_in + "/num_splits", encoding="utf-8")
     num_splits = int(f.readline())
     f.close()
 
@@ -174,7 +174,7 @@ def GetNumWords(lm_dir_in):
 
 
 def GetNgramOrder(lm_dir_in):
-    f = open(lm_dir_in + "/ngram_order")
+    f = open(lm_dir_in + "/ngram_order", encoding="utf-8")
     return int(f.readline())
 
 
@@ -182,7 +182,7 @@ def GetNumGrams(lm_dir_in):
     num_unigrams = 0
     # we generally use num_xgrams to refer to num_ngrams - num_unigrams
     tot_num_xgrams = 0
-    f = open(lm_dir_in + "/num_ngrams")
+    f = open(lm_dir_in + "/num_ngrams", encoding="utf-8")
     for order, line in enumerate(f):
         if order == 0:
             num_unigrams = int(line.split()[1])
@@ -258,7 +258,7 @@ def GetInitialLogprob():
                    float_star=float_star))
     try:
         print(command, file=sys.stderr)
-        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
+        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True, encoding="utf-8")
         # the stdout of this program will be something like:
         # 1.63388e+06 -7.39182e+06 10.5411 41.237 49.6758
         # representing: total-count, total-like, and for each order, the like-change
@@ -284,7 +284,7 @@ def GetInitialLogprob():
 def WriteNumNgrams(out_dir, num_ngrams):
     out_file = out_dir + "/num_ngrams"
     try:
-        f = open(out_file, "w")
+        f = open(out_file, "w", encoding="utf-8")
         for order, num in enumerate(num_ngrams):
             print(str(order + 1) + ' ' + str(num), file=f)
         f.close()
@@ -302,11 +302,11 @@ def RunPruneStep(work_in, work_out, threshold):
                "{work_in}/protected.all {float_star} 2>>{log_file}".format(
                   threshold=threshold, num_words=num_words,
                   work_in=work_in, float_star=float_star, log_file=log_file))
-    with open(log_file, 'w') as f:
+    with open(log_file, 'w', encoding="utf-8") as f:
         print("# " + command, file=f)
     try:
         print(command, file=sys.stderr)
-        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True)
+        p = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True, universal_newlines=True, encoding="utf-8")
         [word_count, like_change] = p.stdout.readline().split()
         like_change_per_word = float(like_change) / float(word_count)
         [tot_xgrams, shadowed, protected, pruned] = p.stdout.readline().split()
@@ -448,7 +448,7 @@ def FinalizeOutput(final_work_out):
     except:
         ExitProgram("error copying {0}/num_ngrams to {1}/num_ngrams".format(
                 final_work_out, args.lm_dir_out))
-    f = open(args.lm_dir_out + "/was_pruned", "w")
+    f = open(args.lm_dir_out + "/was_pruned", "w", encoding="utf-8")
     print("true", file=f)
     f.close()
     for f in ['names', 'words.txt', 'ngram_order', 'metaparameters']:

--- a/scripts/split_lm_dir.py
+++ b/scripts/split_lm_dir.py
@@ -61,7 +61,7 @@ command = ("split-float-counts " +
 if os.system(command) != 0:
     sys.exit("split_lm_dir.py: error running command " + command)
 
-f = open(args.lm_dir_out + "/num_splits", "w")
+f = open(args.lm_dir_out + "/num_splits", "w", encoding="utf-8")
 print(args.num_splits, file=f)
 f.close()
 

--- a/scripts/split_lm_dir.py
+++ b/scripts/split_lm_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/test_metaparameter_derivs.py
+++ b/scripts/test_metaparameter_derivs.py
@@ -69,14 +69,14 @@ command = ("get_objf_and_derivs{split_suffix}.py {split_opt} --derivs-out={deriv
 RunCommand(command)
 
 # get baseline objective function (before perturbing metaparameters).
-f = open(derivs_dir + "/objf")
+f = open(derivs_dir + "/objf", encoding="utf-8")
 baseline_objf = float(f.readline())
 f.close()
 
 # let the metaparameters be a list of 2-tuples
 # (metaparameter-name, value)
 metaparameters = []
-f = open(args.metaparameter_file, "r")
+f = open(args.metaparameter_file, "r", encoding="utf-8")
 for line in f.readlines():
     [name, value] = line.split()
     value = float(value)
@@ -87,7 +87,7 @@ num_metaparameters = len(metaparameters)
 
 
 def WriteMetaparameters(metaparameters, file):
-    f = open(file, "w")
+    f = open(file, "w", encoding="utf-8")
     for t in metaparameters:
         (name, value) = t
         print("{0} {1}".format(name, value), file=f)
@@ -113,21 +113,21 @@ for i in range(num_metaparameters):
     print("test_metaparameter_derivs.py: running command " + command,
           file=sys.stderr)
     RunCommand(command)
-    f = open("{derivs}/objf.{i}".format(derivs=derivs_dir, i=i), "r")
+    f = open("{derivs}/objf.{i}".format(derivs=derivs_dir, i=i), "r", encoding="utf-8")
     modified_objfs[i] = float(f.readline())
     deltas[i] = this_delta
     f.close()
 
 # Now compare the computed derivatives with the 'difference-method' derivatives
 derivs = []
-f = open(derivs_dir + "/derivs", "r")
+f = open(derivs_dir + "/derivs", "r", encoding="utf-8")
 derivs = [float(line.split()[1]) for line in f.readlines()]
 f.close()
 
 output_file = derivs_dir + "/derivs_compare"
 print ("test_metaparameters_derivs.py: writing the analytical and "
        "difference-method derivatives to " + output_file, file=sys.stderr)
-f = open(output_file, "w")
+f = open(output_file, "w", encoding="utf-8")
 print("#parameter-name    analytical derivative    difference-method derivative",
       file=f)
 analytical_sumsq = 0.0

--- a/scripts/test_metaparameter_derivs.py
+++ b/scripts/test_metaparameter_derivs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/text_to_int.py
+++ b/scripts/text_to_int.py
@@ -25,7 +25,7 @@ if not os.path.exists(args.vocab_file):
 
 word_to_index = {}
 
-f = open(args.vocab_file, "r")
+f = open(args.vocab_file, "r", encoding="utf-8")
 
 for line in f:
     try:

--- a/scripts/text_to_int.py
+++ b/scripts/text_to_int.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/train_lm.py
+++ b/scripts/train_lm.py
@@ -139,7 +139,7 @@ if not os.path.isdir(log_dir):
 def GetNumNgrams(lm_dir_in):
     tot_num_ngrams = 0
     num_ngrams = []
-    f = open(os.path.join(lm_dir_in, "num_ngrams"))
+    f = open(os.path.join(lm_dir_in, "num_ngrams"), encoding="utf-8")
     for line in f:
         n = int(line.split()[1])
         num_ngrams.append(n)
@@ -152,7 +152,7 @@ def GetNumNgrams(lm_dir_in):
 
 def ReadMetaparameters(metaparameter_file):
     metaparameters = []
-    f = open(metaparameter_file)
+    f = open(metaparameter_file, encoding="utf-8")
     for line in f:
         metaparameters.append(float(line.split()[1]))
     f.close()
@@ -162,7 +162,7 @@ def ReadMetaparameters(metaparameter_file):
 
 def WriteMetaparameters(metaparameters, ngram_order, num_train_sets, out_file):
     assert(len(metaparameters) == (ngram_order - 1) * 4 + num_train_sets)
-    f = open(out_file, "w")
+    f = open(out_file, "w", encoding="utf-8")
     i = 0
     for n in range(1, num_train_sets + 1):
         print("count_scale_{0}".format(n), metaparameters[i], file=f)
@@ -341,7 +341,7 @@ if args.bypass_metaparameter_optimization is not None:
     LogMessage("Bypass optimization steps")
 
     for name in ['ngram_order', 'num_train_sets']:
-        f = open(os.path.join(counts_dir, name))
+        f = open(os.path.join(counts_dir, name), encoding="utf-8")
         globals()[name] = int(f.readline())
         f.close()
 

--- a/scripts/train_lm.py
+++ b/scripts/train_lm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/validate_count_dir.py
+++ b/scripts/validate_count_dir.py
@@ -27,7 +27,7 @@ if not os.path.exists("{0}/num_train_sets".format(args.count_dir)):
 
 # the following code checks num_train_sets and sets num_train_sets
 # to the appropriate variable.
-f = open("{0}/num_train_sets".format(args.count_dir))
+f = open("{0}/num_train_sets".format(args.count_dir), encoding="utf-8")
 line = f.readline()
 try:
     num_train_sets = int(line)
@@ -39,7 +39,7 @@ except Exception as e:
 f.close()
 
 # the following code checks num_words.
-f = open("{0}/num_words".format(args.count_dir))
+f = open("{0}/num_words".format(args.count_dir), encoding="utf-8")
 line = f.readline()
 try:
     num_words = int(line)
@@ -54,7 +54,7 @@ f.close()
 # the following code checks split_modulus (which doesn't have to exist,
 # it's optional).
 if os.path.exists("{0}/split_modulus".format(args.count_dir)):
-    f = open("{0}/num_words".format(args.count_dir))
+    f = open("{0}/num_words".format(args.count_dir), encoding="utf-8")
     line = f.readline()
     try:
         split_modulus = int(line)
@@ -66,7 +66,7 @@ if os.path.exists("{0}/split_modulus".format(args.count_dir)):
     f.close()
 
 # the following code checks ngram_order
-f = open("{0}/ngram_order".format(args.count_dir))
+f = open("{0}/ngram_order".format(args.count_dir), encoding="utf-8")
 line = f.readline()
 try:
     ngram_order = int(line)
@@ -89,7 +89,7 @@ names = set()
 #  1 switchboard
 #  2 fisher
 # etc.
-f = open("{0}/names".format(args.count_dir))
+f = open("{0}/names".format(args.count_dir), encoding="utf-8")
 for n in range(1, num_train_sets + 1):
     line = f.readline()
     try:
@@ -108,7 +108,7 @@ f.close()
 # is an optional part of the directory format; we put it here so it can be used
 # to initialize the metaparameters in a reasonable way.
 if os.path.exists("{0}/unigram_weights".format(args.count_dir)):
-    f = open("{0}/unigram_weights".format(args.count_dir))
+    f = open("{0}/unigram_weights".format(args.count_dir), encoding="utf-8")
     names_with_weights = set()
     while True:
         line = f.readline()

--- a/scripts/validate_count_dir.py
+++ b/scripts/validate_count_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/validate_int_dir.py
+++ b/scripts/validate_int_dir.py
@@ -125,7 +125,7 @@ for n in range(1, num_train_sets + 1):
     names.append(str(n))
 
 for name in names:
-    p = subprocess.Popen("gunzip -c {0}/{1}.txt.gz 2>/dev/null".format(args.int_dir, name, encoding="utf-8"),
+    p = subprocess.Popen("gunzip -c {0}/{1}.txt.gz 2>/dev/null".format(args.int_dir, name),
                          stdout=subprocess.PIPE, shell=True)
     num_ints = 0
     for l in range(10):

--- a/scripts/validate_int_dir.py
+++ b/scripts/validate_int_dir.py
@@ -31,7 +31,7 @@ if not os.path.exists("{0}/num_train_sets".format(args.int_dir)):
 
 # the following code checks num_train_sets and sets num_train_sets
 # to the appropriate variable.
-f = open("{0}/num_train_sets".format(args.int_dir))
+f = open("{0}/num_train_sets".format(args.int_dir), encoding="utf-8")
 line = f.readline()
 try:
     num_train_sets = int(line)
@@ -43,7 +43,7 @@ except Exception as e:
 f.close()
 
 # the following code checks num_words.
-f = open("{0}/num_words".format(args.int_dir))
+f = open("{0}/num_words".format(args.int_dir), encoding="utf-8")
 line = f.readline()
 try:
     num_words = int(line)
@@ -73,7 +73,7 @@ names = set()
 #  1 switchboard
 #  2 fisher
 # etc.
-f = open("{0}/names".format(args.int_dir))
+f = open("{0}/names".format(args.int_dir), encoding="utf-8")
 for n in range(1, num_train_sets + 1):
     line = f.readline()
     try:
@@ -92,7 +92,7 @@ f.close()
 # is an optional part of the directory format; we put it here so it can be used
 # to initialize the metaparameters in a reasonable way.
 if os.path.exists("{0}/unigram_weights".format(args.int_dir)):
-    f = open("{0}/unigram_weights".format(args.int_dir))
+    f = open("{0}/unigram_weights".format(args.int_dir), encoding="utf-8")
     names_with_weights = set()
     while True:
         line = f.readline()
@@ -125,7 +125,7 @@ for n in range(1, num_train_sets + 1):
     names.append(str(n))
 
 for name in names:
-    p = subprocess.Popen("gunzip -c {0}/{1}.txt.gz 2>/dev/null".format(args.int_dir, name),
+    p = subprocess.Popen("gunzip -c {0}/{1}.txt.gz 2>/dev/null".format(args.int_dir, name, encoding="utf-8"),
                          stdout=subprocess.PIPE, shell=True)
     num_ints = 0
     for l in range(10):

--- a/scripts/validate_int_dir.py
+++ b/scripts/validate_int_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/validate_lm_dir.py
+++ b/scripts/validate_lm_dir.py
@@ -22,7 +22,7 @@ if not os.path.exists(args.lm_dir):
     sys.exit("validate_lm_dir.py: Expected directory {0} to exist".format(args.lm_dir))
 
 # the following code checks ngram_order
-f = open("{0}/ngram_order".format(args.lm_dir))
+f = open("{0}/ngram_order".format(args.lm_dir), encoding="utf-8")
 line = f.readline()
 try:
     ngram_order = int(line)
@@ -35,7 +35,7 @@ f.close()
 
 # the following code checks num_ngrams
 try:
-    f = open("{0}/num_ngrams".format(args.lm_dir))
+    f = open("{0}/num_ngrams".format(args.lm_dir), encoding="utf-8")
     lines = f.readlines()
     assert(len(lines) == ngram_order)
     for order, line in enumerate(lines):
@@ -62,7 +62,7 @@ if os.system("echo true | cmp -s - {0}/was_pruned || "
 #  1 switchboard
 #  2 fisher
 # etc.
-f = open("{0}/names".format(args.lm_dir))
+f = open("{0}/names".format(args.lm_dir), encoding="utf-8")
 num_train_sets = 0
 while True:
     line = f.readline()
@@ -80,7 +80,7 @@ f.close()
 
 if os.path.exists(args.lm_dir + "/num_splits"):
     # split LM dir, contains float.all.split{1,2,3..}
-    f = open(args.lm_dir + "/num_splits")
+    f = open(args.lm_dir + "/num_splits", encoding="utf-8")
     try:
         num_splits = int(f.readline())
         assert f.readline() == '' and num_splits > 1

--- a/scripts/validate_lm_dir.py
+++ b/scripts/validate_lm_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/validate_metaparameter_derivs.py
+++ b/scripts/validate_metaparameter_derivs.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/validate_metaparameter_derivs.py
+++ b/scripts/validate_metaparameter_derivs.py
@@ -41,8 +41,8 @@ if not os.path.exists(args.metaparameter_derivs):
              " to exist".format(args.metaparameter_derivs))
 
 try:
-    f = open(args.metaparameter_file, "r")
-    deriv_f = open(args.metaparameter_derivs, "r")
+    f = open(args.metaparameter_file, "r", encoding="utf-8")
+    deriv_f = open(args.metaparameter_derivs, "r", encoding="utf-8")
 except:
     sys.exit("validate_metaparameter_derivs.py: error opening {0} or {1}".format(
         args.metaparameter_file, args.metaparameter_derivs))

--- a/scripts/validate_metaparameters.py
+++ b/scripts/validate_metaparameters.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/validate_metaparameters.py
+++ b/scripts/validate_metaparameters.py
@@ -35,7 +35,7 @@ if not os.path.exists(args.metaparameter_file):
              " to exist".format(args.metaparameter_file))
 
 try:
-    f = open(args.metaparameter_file, "r")
+    f = open(args.metaparameter_file, "r", encoding="utf-8")
 except:
     sys.exit("validate_metaparameters.py: error opening metaparameters file " +
              args.metaparameter_file)

--- a/scripts/validate_text_dir.py
+++ b/scripts/validate_text_dir.py
@@ -36,9 +36,9 @@ num_text_files = 0
 def SpotCheckTextFile(text_file):
     try:
         if text_file.endswith(".gz"):
-            f = gzip.open(text_file, 'r')
+            f = gzip.open(text_file, 'rt', encoding="utf-8")
         else:
-            f = open(text_file, 'r')
+            f = open(text_file, 'r', encoding="utf-8")
     except Exception as e:
         sys.exit("validate_text_dir.py: Failed to open {0} for reading: {1}".format(
                 text_file, str(e)))
@@ -62,9 +62,9 @@ def SpotCheckTextFile(text_file):
     # with some kind of utterance-id
     f.close()
     if text_file.endswith(".gz"):
-        f = gzip.open(text_file, 'r')
+        f = gzip.open(text_file, 'rt', encoding="utf-8")
     else:
-        f = open(text_file, 'r')
+        f = open(text_file, 'r', encoding="utf-8")
     first_field_set = set()
     other_fields_set = set()
     for line in f:

--- a/scripts/validate_text_dir.py
+++ b/scripts/validate_text_dir.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/validate_vocab.py
+++ b/scripts/validate_vocab.py
@@ -40,7 +40,7 @@ likely_special_indexes.add((3, '<Unk>'))
 default_special_indexes = ['<eps>', '<s>', '</s>', '<unk>']
 
 
-f = open(args.vocab_file, "r")
+f = open(args.vocab_file, "r", encoding='utf-8')
 num_lines = 0
 for line in f:
     try:

--- a/scripts/validate_vocab.py
+++ b/scripts/validate_vocab.py
@@ -40,7 +40,7 @@ likely_special_indexes.add((3, '<Unk>'))
 default_special_indexes = ['<eps>', '<s>', '</s>', '<unk>']
 
 
-f = open(args.vocab_file, "r", encoding='utf-8')
+f = open(args.vocab_file, "r", encoding='utf-8', encoding="utf-8")
 num_lines = 0
 for line in f:
     try:

--- a/scripts/validate_vocab.py
+++ b/scripts/validate_vocab.py
@@ -40,7 +40,7 @@ likely_special_indexes.add((3, '<Unk>'))
 default_special_indexes = ['<eps>', '<s>', '</s>', '<unk>']
 
 
-f = open(args.vocab_file, "r", encoding='utf-8', encoding="utf-8")
+f = open(args.vocab_file, "r", encoding='utf-8')
 num_lines = 0
 for line in f:
     try:

--- a/scripts/validate_vocab.py
+++ b/scripts/validate_vocab.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # we're using python 3.x style print but want it to work in python 2.x,
 from __future__ import print_function

--- a/scripts/word_counts_to_vocab.py
+++ b/scripts/word_counts_to_vocab.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # We're using python 3.x style print but want it to work in python 2.x.
 from __future__ import print_function

--- a/scripts/word_counts_to_vocab.py
+++ b/scripts/word_counts_to_vocab.py
@@ -57,7 +57,7 @@ args = parser.parse_args()
 # read in the weights.
 name_to_weight = {}
 if args.weights is not None:
-    f = open(args.weights, 'r')
+    f = open(args.weights, 'r', encoding="utf-8")
     num_weights_read = 0
     for line in f:
         try:
@@ -105,7 +105,7 @@ for name in os.listdir(args.count_dir):
             weight = 1.0
             saw_counts_without_weight = True
         counts_path = args.count_dir + os.sep + name
-        f = open(counts_path, 'r')
+        f = open(counts_path, 'r', encoding="utf-8")
         for line in f:
             try:
                 [count, word] = line.split()

--- a/scripts/wordlist_to_vocab.py
+++ b/scripts/wordlist_to_vocab.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # We're using python 3.x style print but want it to work in python 2.x.
 from __future__ import print_function

--- a/scripts/wordlist_to_vocab.py
+++ b/scripts/wordlist_to_vocab.py
@@ -37,7 +37,7 @@ parser.add_argument('wordlist',
 args = parser.parse_args()
 
 # read in the weights.
-words = open(args.wordlist, "r").readlines()
+words = open(args.wordlist, "r").readlines(, encoding="utf-8")
 if len(words) <= 1:
     sys.exit("wordlist_to_vocab.py: input word-list {0} has only {1} lines".format(
             args.wordlist, len(words)))

--- a/scripts/wordlist_to_vocab.py
+++ b/scripts/wordlist_to_vocab.py
@@ -37,7 +37,7 @@ parser.add_argument('wordlist',
 args = parser.parse_args()
 
 # read in the weights.
-words = open(args.wordlist, "r").readlines(, encoding="utf-8")
+words = open(args.wordlist, "r", encoding="utf-8").readlines()
 if len(words) <= 1:
     sys.exit("wordlist_to_vocab.py: input word-list {0} has only {1} lines".format(
             args.wordlist, len(words)))


### PR DESCRIPTION
The issue is when dealing with a text resource containing non-ASCII symbols - because some environment variables (e.g. `LC_ALL=C`) are being set somewhere in the middle of running `train_lm.py`, Python's `open()` does not correctly detect input encoding. 

IMO it's safe to assume that UTF-8 is the standard way of encoding text data today, which is why I'm suggesting to just hard-code it. 

Would you be so kind as to merge this or suggest a different approach to supporting non-ASCII characters?