### PR TITLE
starting from OS X 10.9 (Mavericks) libc++ has become the default C++…

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -30,8 +30,8 @@ CXXFLAGS += -Wall -g
 LDFLAGS += -g
 
 ifeq ($(shell uname), Darwin)
- CXXFLAGS += -stdlib=libstdc++
- LDFLAGS += -stdlib=libstdc++
+ CXXFLAGS += -std=c++11 -stdlib=libc++
+ LDFLAGS += -std=c++11 -stdlib=libc++
 endif
 
 LDLIBS =


### PR DESCRIPTION
Code compiles on Mac after the changes.
http://ease-the-computation.haunted.io/compile-clang-against-libstdc-with-c11-support-on-a-mac/

