### PR TITLE
Update GetNumWords to use utf-8 encoding

### DIFF
--- a/scripts/prepare_int_data.py
+++ b/scripts/prepare_int_data.py
@@ -72,7 +72,8 @@ def GetNumWords(vocab):
     command = "tail -n 1 {0}".format(vocab)
     line = subprocess.check_output(command,
                                    shell=True,
-                                   universal_newlines=True)
+                                   universal_newlines=True,
+                                   encoding='utf-8')
     try:
         a = line.split()
         assert len(a) == 2

--- a/scripts/prune_lm_dir.py
+++ b/scripts/prune_lm_dir.py
@@ -217,7 +217,8 @@ def GetNumWords(lm_dir_in):
     command = "tail -n 1 {0}/words.txt".format(lm_dir_in)
     line = subprocess.check_output(command,
                                    shell=True,
-                                   universal_newlines=True)
+                                   universal_newlines=True,
+                                   encoding='utf-8')
     try:
         a = line.split()
         assert len(a) == 2


### PR DESCRIPTION
This pull request fixes the `GetNumWords` method in `prepare_int_data.py` and `prune_lm_dir.py` by setting the encoding as `utf-8`.

Currently the following errors occur when working on [Telugu](https://iso639-3.sil.org/code/tel), [Tamil](https://iso639-3.sil.org/code/tam) and presumably other languages due to encoding issues : 
```
Traceback (most recent call last):
  File "/home/sourya4/kaldi/egs/tamil_telugu_proj/s5_r3/../../../tools/pocolm/scripts/prepare_int_data.py", line 168, in <module>
    num_words = GetNumWords(args.vocab)
  File "/home/sourya4/kaldi/egs/tamil_telugu_proj/s5_r3/../../../tools/pocolm/scripts/prepare_int_data.py", line 75, in GetNumWords
    universal_newlines=True)
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 425, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.6/subprocess.py", line 850, in communicate
    stdout = self.stdout.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe0 in position 0: ordinal not in range(128)
# exited with return code 1 after 0.3 seconds
```

```
Traceback (most recent call last):
  File "/home/sourya4/kaldi/egs/tamil_telugu_proj/s5_r3/../../../tools/pocolm/scripts/prune_lm_dir.py", line 613, in <module>
    num_words = GetNumWords(args.lm_dir_in)
  File "/home/sourya4/kaldi/egs/tamil_telugu_proj/s5_r3/../../../tools/pocolm/scripts/prune_lm_dir.py", line 220, in GetNumWords
    universal_newlines=True)
  File "/usr/lib/python3.6/subprocess.py", line 356, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.6/subprocess.py", line 425, in run
    stdout, stderr = process.communicate(input, timeout=timeout)
  File "/usr/lib/python3.6/subprocess.py", line 850, in communicate
    stdout = self.stdout.read()
  File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe0 in position 0: ordinal not in range(128)
```